### PR TITLE
add white balance launch args to front camera mission files

### DIFF
--- a/perception_setup/launch/mission/pipeline_inspection/pipeline_inspection_front_camera.launch.py
+++ b/perception_setup/launch/mission/pipeline_inspection/pipeline_inspection_front_camera.launch.py
@@ -264,6 +264,16 @@ def generate_launch_description():
                 default_value='true',
                 description='Publish debug annotated images from YOLO seg.',
             ),
+            DeclareLaunchArgument(
+                'enable_auto_white_balance',
+                default_value='false',
+                description='Enable auto white balance on the color camera. When false, white_balance is used.',
+            ),
+            DeclareLaunchArgument(
+                'white_balance',
+                default_value='4500.0',
+                description='Manual white balance value (Kelvin). Only applied when enable_auto_white_balance=false.',
+            ),
             OpaqueFunction(function=_launch_setup),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
@@ -281,6 +291,10 @@ def generate_launch_description():
                     'enable_gstreamer': 'false',
                     'standalone': 'false',
                     'container_name': 'front_camera_container',
+                    'enable_auto_white_balance': LaunchConfiguration(
+                        'enable_auto_white_balance'
+                    ),
+                    'white_balance': LaunchConfiguration('white_balance'),
                 }.items(),
                 condition=UnlessCondition(LaunchConfiguration('sim')),
             ),

--- a/perception_setup/launch/mission/subsea_docking/subsea_docking_front_camera.launch.py
+++ b/perception_setup/launch/mission/subsea_docking/subsea_docking_front_camera.launch.py
@@ -59,7 +59,7 @@ def _launch_setup(context, *args, **kwargs):
     ) as f:
         robot_topics = yaml.safe_load(f)['/**']['ros__parameters']['topics']
 
-    sim = LaunchConfiguration('sim').perform(context).lower() == 'true'
+    sim = LaunchConfiguration('sim').perform(context).lower() == 'true'  # noqa: F841
     target = LaunchConfiguration('target').perform(context)
     enable_gstreamer = (
         LaunchConfiguration('enable_gstreamer').perform(context).lower() == 'true'
@@ -92,41 +92,45 @@ def _launch_setup(context, *args, **kwargs):
             plugin='ArucoDetectorNode',
             name='front_aruco_detector',
             namespace=namespace,
-            parameters=[{
-                'subs.image_topic': color_image_topic,
-                'subs.camera_info_topic': camera_info_topic,
-                'pubs.aruco_image': '/aruco_detector/image_front',
-                'pubs.aruco_poses': '/aruco_detector/markers_front',
-                'pubs.board_pose': '/aruco_detector/board_front',
-                'pubs.landmarks': f'/{namespace}/{robot_topics["landmarks"]}',
-                'logger_service_name': '/toggle_marker_logger',
-                'detect_board': True,
-                'visualize': True,
-                'log_markers': False,
-                'publish_detections': True,
-                'publish_landmarks': True,
-                'aruco.dictionary': 'DICT_ARUCO_ORIGINAL',
-                'enu_ned_rotation': True,
-                'out_tf_frame': f'{namespace}/front_camera_optical',
-                **aruco_params,
-            }],
+            parameters=[
+                {
+                    'subs.image_topic': color_image_topic,
+                    'subs.camera_info_topic': camera_info_topic,
+                    'pubs.aruco_image': '/aruco_detector/image_front',
+                    'pubs.aruco_poses': '/aruco_detector/markers_front',
+                    'pubs.board_pose': '/aruco_detector/board_front',
+                    'pubs.landmarks': f'/{namespace}/{robot_topics["landmarks"]}',
+                    'logger_service_name': '/toggle_marker_logger',
+                    'detect_board': True,
+                    'visualize': True,
+                    'log_markers': False,
+                    'publish_detections': True,
+                    'publish_landmarks': True,
+                    'aruco.dictionary': 'DICT_ARUCO_ORIGINAL',
+                    'enu_ned_rotation': True,
+                    'out_tf_frame': f'{namespace}/front_camera_optical',
+                    **aruco_params,
+                }
+            ],
             extra_arguments=[{'use_intra_process_comms': True}],
         ),
         ComposableNode(
             package='vortex_cv_util_nodes',
             plugin='vortex_cv_util_nodes::ImageRoiCrop',
             name='front_camera_bottom_crop',
-            parameters=[{
-                'image_topic': color_image_topic,
-                'camera_info_topic': camera_info_topic,
-                'output_image_topic': cropped_image_topic,
-                'output_camera_info_topic': cropped_camera_info_topic,
-                'enable_crop': True,
-                'crop.x_offset': 0,
-                'crop.y_offset': 0,
-                'crop.width': 0,
-                'crop.height': img_height - 150,
-            }],
+            parameters=[
+                {
+                    'image_topic': color_image_topic,
+                    'camera_info_topic': camera_info_topic,
+                    'output_image_topic': cropped_image_topic,
+                    'output_camera_info_topic': cropped_camera_info_topic,
+                    'enable_crop': True,
+                    'crop.x_offset': 0,
+                    'crop.y_offset': 0,
+                    'crop.width': 0,
+                    'crop.height': img_height - 150,
+                }
+            ],
             extra_arguments=[{'use_intra_process_comms': True}],
         ),
     ]
@@ -225,13 +229,15 @@ def _launch_setup(context, *args, **kwargs):
                 package='docking_camera_yolo_direction_waypoint',
                 plugin='vortex::docking_camera_yolo_direction_waypoint::DockingCameraYoloDirectionWaypointNode',
                 name='docking_camera_yolo_direction_waypoint',
-                parameters=[{
-                    'detection_sub_topic': '/yolo/docking_detections',
-                    'camera_info_sub_topic': cropped_camera_info_topic,
-                    'landmarks_pub_topic': f'/{namespace}/{robot_topics["landmarks"]}',
-                    'odom_frame': f'{namespace}/odom',
-                    'waypoint_distance': float(waypoint_distance),
-                }],
+                parameters=[
+                    {
+                        'detection_sub_topic': '/yolo/docking_detections',
+                        'camera_info_sub_topic': cropped_camera_info_topic,
+                        'landmarks_pub_topic': f'/{namespace}/{robot_topics["landmarks"]}',
+                        'odom_frame': f'{namespace}/odom',
+                        'waypoint_distance': float(waypoint_distance),
+                    }
+                ],
                 extra_arguments=[{'use_intra_process_comms': True}],
             )
         )
@@ -345,6 +351,16 @@ def generate_launch_description():
                 default_value='15',
                 description='RealSense camera frame rate.',
             ),
+            DeclareLaunchArgument(
+                'enable_auto_white_balance',
+                default_value='false',
+                description='Enable auto white balance on the color camera. When false, white_balance is used.',
+            ),
+            DeclareLaunchArgument(
+                'white_balance',
+                default_value='4500.0',
+                description='Manual white balance value (Kelvin). Only applied when enable_auto_white_balance=false.',
+            ),
             OpaqueFunction(function=_launch_setup),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
@@ -364,6 +380,10 @@ def generate_launch_description():
                     'enable_gstreamer': 'false',
                     'standalone': 'false',
                     'container_name': 'front_camera_container',
+                    'enable_auto_white_balance': LaunchConfiguration(
+                        'enable_auto_white_balance'
+                    ),
+                    'white_balance': LaunchConfiguration('white_balance'),
                 }.items(),
                 condition=UnlessCondition(LaunchConfiguration('sim')),
             ),

--- a/perception_setup/launch/mission/valve_intervention/valve_intervention.launch.py
+++ b/perception_setup/launch/mission/valve_intervention/valve_intervention.launch.py
@@ -56,6 +56,10 @@ def _launch_setup(context, *args, **kwargs):
         LaunchConfiguration('enable_subtype_resolver').perform(context).lower()
         == 'true'
     )
+    enable_auto_white_balance = LaunchConfiguration(
+        'enable_auto_white_balance'
+    ).perform(context)
+    white_balance = LaunchConfiguration('white_balance').perform(context)
 
     # All downstream nodes subscribe to these drone-prefixed topics.
     # Real hardware: camera + undistort publish here.
@@ -234,6 +238,8 @@ def _launch_setup(context, *args, **kwargs):
                     'enable_gstreamer': 'false',
                     'standalone': 'false',
                     'container_name': container_name,
+                    'enable_auto_white_balance': enable_auto_white_balance,
+                    'white_balance': white_balance,
                 }.items(),
             )
         )
@@ -342,6 +348,16 @@ def generate_launch_description():
                 'destination_port',
                 default_value='5000',
                 description='Destination UDP port for GStreamer RTP stream.',
+            ),
+            DeclareLaunchArgument(
+                'enable_auto_white_balance',
+                default_value='false',
+                description='Enable auto white balance on the color camera. When false, white_balance is used.',
+            ),
+            DeclareLaunchArgument(
+                'white_balance',
+                default_value='4500.0',
+                description='Manual white balance value (Kelvin). Only applied when enable_auto_white_balance=false.',
             ),
             OpaqueFunction(function=_launch_setup),
         ]


### PR DESCRIPTION
Expose enable_auto_white_balance and white_balance as launch arguments in pipeline_inspection, subsea_docking, and valve_intervention front camera launch files, forwarding them into realsense_d555.launch.py.

We need to test this works before combining with development branch!